### PR TITLE
fixes issue where code bombs when not run on the original gluster peer member

### DIFF
--- a/src/peer/status.py
+++ b/src/peer/status.py
@@ -47,9 +47,10 @@ def _status(remotehost="localhost",recursion=False):
                 if x not in peerstatus["host"].keys()][0]
         peerstatus["host"][remotehost] = {}
         peerstatus["host"][remotehost]["self"] = True
-        peerstatus["host"][remotehost]["uuid"] = _status(remotehost=peerstatus["host"].keys()[0],recursion=True)["host"][remotehost]["uuid"]
         peerstatus["host"][remotehost]["state"] = {}
         for host in peerstatus["host"].keys():
+            if host != remotehost:
+                peerstatus["host"][remotehost]["uuid"] = _status(remotehost=host,recursion=True)["host"][remotehost]["uuid"]
             remotestatus = _status(host,recursion=True)
             for statehost in remotestatus["host"]:
                 for state in remotestatus["host"][statehost]["state"]:


### PR DESCRIPTION
fixes issue where doing 'status = gluster.peer.status()' on nodes where self = true is the first item in the dict results in: 
Traceback (most recent call last):
  File "./monitor.py", line 8, in <module>
    status = gluster.peer.status()         # retrieve peer status from all servers
  File "/root/python-gluster/gluster/peer/status.py", line 12, in status
    return _status(remotehost)
  File "/root/python-gluster/gluster/peer/status.py", line 55, in _status
    peerstatus["host"][remotehost]["uuid"] = _status(remotehost=peerstatus["host"].keys()[0],recursion=True)["host"][remotehost]["uuid"]
KeyError: '192.168.1.122'
